### PR TITLE
fix: ngrx-action-hygiene should only verify action name in createAction

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "copy:schematics": "cp ./src/schematics/collection.json ./dist/schematics & cp ./src/schematics/ng-add/schema.json ./dist/schematics/ng-add",
     "generate-schema": "ts-node ./src/scripts/generate-schema.ts",
     "lint": "tslint -p .",
+    "build-and-test": "npm run build && npm run test:rules",
     "test": "npm run test:schematics && npm run test:rules",
     "test:schematics": "jest --config ./test/jest.config.json",
     "test:rules": "tslint --test ./test/rules/**/tslint.json",

--- a/test/rules/ngrx-action-hygiene/fixture.ts.lint
+++ b/test/rules/ngrx-action-hygiene/fixture.ts.lint
@@ -38,4 +38,18 @@ const action = createAction(
 
 const action = createAction('[Customers] load', ( page: number ) => ({ page }))
 
+
+// https://github.com/timdeschryver/ngrx-tslint-rules/issues/22
+describe("application reducers", () => {
+  describe("appInit reducers", () => {
+    it("should return the initial state", () => {
+      let newState = initializationStateReducer(undefined, createAction("[App Tests] Init"));
+      expect(newState).toEqual(appInitInitialState);
+
+      newState = initializationStateReducer(undefined, initializeApplication);
+      expect(newState).toEqual(appInitInitialState);
+    });
+  });
+});
+
 [action-hygiene]: Action type does not follow the good action hygiene practice, use "[Source] Event" to define action types


### PR DESCRIPTION
Closes #22 