### PR TITLE
Add new rule for on reducer explicit return type

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,3 +1,4 @@
 * text=auto
 *.js text eol=lf
 *.ts text eol=lf
+*.lint eol=lf

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Next, add `ngrx-tslint-rules` to your `tslint.json` file, and the rules to the `
 }
 ```
 
-To enable all rules, use the `recommended` configuration file.
+To enable all recommended rules, use the `recommended` configuration file.
 
 ```json
 {
@@ -42,7 +42,7 @@ To enable all rules, use the `recommended` configuration file.
 
 > The recommended rules also export the rules from [rxjs-tslint-rules](https://github.com/cartant/rxjs-tslint-rules) that can be applied to NgRx
 
-## Rules
+## Recommend Rules
 
 > By default all rules are enabled
 
@@ -60,6 +60,23 @@ To enable all rules, use the `recommended` configuration file.
 | ngrx-no-reducer-in-key-names                         | Avoid the word "reducer" in the key names                                                                                      | [Example](https://github.com/timdeschryver/ngrx-tslint-rules/tree/master/test/rules/ngrx-no-reducer-in-key-names/fixture.ts.lint)                         |
 | ngrx-no-typed-store                                  | A store should not be typed                                                                                                    | [Example](https://github.com/timdeschryver/ngrx-tslint-rules/tree/master/test/rules/ngrx-no-typed-store/fixture.ts.lint)                                  |
 | ngrx-selector-for-select                             | Using string or props drilling is not preferred, use a selector instead                                                        | [Example](https://github.com/timdeschryver/ngrx-tslint-rules/tree/master/test/rules/ngrx-selector-for-select/fixture.ts.lint)                             |
+
+## Optional Rules
+
+To enable optional rules add them to the `rules` section in your `tslint.json` file.
+
+```json
+{
+  "extends": ["ngrx-tslint-rules"],
+  "rules": {
+    "ngrx-on-reducer-explicit-return-type": true
+  }
+}
+```
+
+| Rule                                 | Description                                     | Examples                                                                                                                                  |
+| ------------------------------------ | ----------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------- |
+| ngrx-on-reducer-explicit-return-type | Enforces type safety for `on` reducer callbacks | [Example](https://github.com/timdeschryver/ngrx-tslint-rules/tree/master/test/rules/ngrx-on-reducer-explicit-return-type/fixture.ts.lint) |
 
 ## License
 

--- a/src/rules/ngrxOnReducerExplicitReturnTypeRule.ts
+++ b/src/rules/ngrxOnReducerExplicitReturnTypeRule.ts
@@ -1,0 +1,42 @@
+import { tsquery } from '@phenomnomnominal/tsquery'
+import * as Lint from 'tslint'
+import * as ts from 'typescript'
+
+export class Rule extends Lint.Rules.TypedRule {
+  public static metadata: Lint.IRuleMetadata = {
+    description: 'On reducer should have an explicit return type',
+    descriptionDetails:
+      'This rule forces the on reducer to have an explicit return type when defined with an arrow function.',
+    options: null,
+    optionsDescription: 'Not configurable',
+    requiresTypeInfo: false,
+    ruleName: 'ngrx-on-reducer-explicit-return-type',
+    type: 'maintainability',
+    typescriptOnly: true,
+  }
+
+  public static FAILURE_STRING =
+    'On reducers should have an explicit return type when using arrow functions, on(action, (state):State => {}'
+
+  public applyWithProgram(
+    sourceFile: ts.SourceFile,
+    program: ts.Program,
+  ): Lint.RuleFailure[] {
+    const creators = tsquery(
+      sourceFile,
+      'CallExpression:has(Identifier[name=createReducer])  CallExpression:has(Identifier[name=on]) ArrowFunction:not(:has(TypeReference),:has(CallExpression))',
+    ) as ts.CallExpression[]
+
+    const failures = creators.map(
+      (node): Lint.RuleFailure =>
+        new Lint.RuleFailure(
+          sourceFile,
+          node.getStart(),
+          node.getStart() + node.getWidth(),
+          Rule.FAILURE_STRING,
+          this.ruleName,
+        ),
+    )
+    return failures
+  }
+}

--- a/test/rules/ngrx-on-reducer-explicit-return-type/actions.ts
+++ b/test/rules/ngrx-on-reducer-explicit-return-type/actions.ts
@@ -1,0 +1,4 @@
+import { createAction, props } from '@ngrx/store'
+
+export const increment = createAction('increment')
+export const increase = createAction('increase', props<{ value: number }>())

--- a/test/rules/ngrx-on-reducer-explicit-return-type/fixture.ts.lint
+++ b/test/rules/ngrx-on-reducer-explicit-return-type/fixture.ts.lint
@@ -18,7 +18,7 @@ function increaseFunc(state: State, value: number): State {
 const reducer = createReducer(
   initialState,
 
-  // No explicit return type when no action props
+  // No explicit return type defined means values can be assigned to non-existent properties.
   on(increment, s => ({
                 ~~~~~~~
     ...s,
@@ -34,12 +34,12 @@ const reducer = createReducer(
       counter: s.counter + 1,
     }),
   ),
-  // Do not require functions to have an explicit return type defined in on method
+  // Do not require functions to have an explicit return type as likely that the function is typed
   on(increment, incrementFunc),
   on(increment, s => incrementFunc(s)),
   on(increment, (s): State => incrementFunc(s)),
 
-  // No explicit return type when action has props
+  // No explicit return type
   on(increase, (s, action) => ({
                ~~~~~~~~~~~~~~~~~
     ...s,
@@ -55,7 +55,7 @@ on(
     counter: s.counter + action.value,
   }),
 ),
-// No explicit return type when action has props and deconstructed
+// No explicit return type
 on(increase, (s, { value }) => ({
              ~~~~~~~~~~~~~~~~~~~~
   ...s,

--- a/test/rules/ngrx-on-reducer-explicit-return-type/fixture.ts.lint
+++ b/test/rules/ngrx-on-reducer-explicit-return-type/fixture.ts.lint
@@ -1,0 +1,81 @@
+import { createReducer, on, select, createAction } from '@ngrx/store'
+import { increase, increment } from './actions'
+
+interface State {
+  counter: number
+}
+const initialState: State = {
+  counter: 0,
+}
+
+function incrementFunc(state: State): State {
+  return { ...state, counter: state.counter + 1 }
+}
+function increaseFunc(state: State, value: number): State {
+  return { ...state, counter: state.counter + value }
+}
+
+const reducer = createReducer(
+  initialState,
+
+  // No explicit return type when no action props
+  on(increment, s => ({
+                ~~~~~~~
+    ...s,
+~~~~~~~~~
+    counter: s.counter + 1,
+~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  })),
+~~~~                                              [on-reducer-explicit-return-type]
+  on(
+    increment,
+    (s): State => ({
+      ...s,
+      counter: s.counter + 1,
+    }),
+  ),
+  // Do not require functions to have an explicit return type defined in on method
+  on(increment, incrementFunc),
+  on(increment, s => incrementFunc(s)),
+  on(increment, (s): State => incrementFunc(s)),
+
+  // No explicit return type when action has props
+  on(increase, (s, action) => ({
+               ~~~~~~~~~~~~~~~~~
+    ...s,
+~~~~~~~~~
+    counter: s.counter + action.value,
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  })),
+~~~~                                              [on-reducer-explicit-return-type]
+on(
+  increase,
+  (s, action): State => ({
+    ...s,
+    counter: s.counter + action.value,
+  }),
+),
+// No explicit return type when action has props and deconstructed
+on(increase, (s, { value }) => ({
+             ~~~~~~~~~~~~~~~~~~~~
+  ...s,
+~~~~~~~
+  counter: s.counter + value,
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+})),
+~~                                              [on-reducer-explicit-return-type]
+on(
+  increase,
+  (s, { value }): State => ({
+    ...s,
+    counter: s.counter + value,
+  }),
+),
+on(increase, (s, { value }) => increaseFunc(s, value)),
+on(increase, (s, { value }): State => increaseFunc(s, value))
+
+)
+
+
+[on-reducer-explicit-return-type]: On reducers should have an explicit return type when using arrow functions, on(action, (state):State => {}
+

--- a/test/rules/ngrx-on-reducer-explicit-return-type/tsconfig.json
+++ b/test/rules/ngrx-on-reducer-explicit-return-type/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "compilerOptions": {
+    "baseUrl": ".",
+    "lib": ["es2015"],
+    "noEmit": true,
+    "paths": {
+      "@ngrx/store": ["../../../node_modules/@ngrx/store"],
+      "rxjs": ["../../../node_modules/rxjs"]
+    },
+    "skipLibCheck": true,
+    "target": "es5"
+  }
+}

--- a/test/rules/ngrx-on-reducer-explicit-return-type/tslint.json
+++ b/test/rules/ngrx-on-reducer-explicit-return-type/tslint.json
@@ -1,0 +1,7 @@
+{
+  "defaultSeverity": "error",
+  "rules": {
+    "ngrx-on-reducer-explicit-return-type": true
+  },
+  "rulesDirectory": ["../../../dist/rules"]
+}


### PR DESCRIPTION
While https://github.com/ngrx/platform/issues/2412 is still outstanding I feel like there is value in adding a rule that will warn about un-typed arrow functions in `on` reducer methods. This will prevent bugs caused by the spread operator not enforcing the properties without an explicit return type.

Rule will be opt in as it may cause a lot of 'breaks' if part of the default set  of rules.

