### PR TITLE
ngrx-on-reducer-explicit-return-type matches nested arrow functions

### DIFF
--- a/src/rules/ngrxOnReducerExplicitReturnTypeRule.ts
+++ b/src/rules/ngrxOnReducerExplicitReturnTypeRule.ts
@@ -24,7 +24,7 @@ export class Rule extends Lint.Rules.TypedRule {
   ): Lint.RuleFailure[] {
     const creators = tsquery(
       sourceFile,
-      'CallExpression:has(Identifier[name=createReducer])  CallExpression:has(Identifier[name=on]) ArrowFunction:not(:has(TypeReference),:has(CallExpression))',
+      'CallExpression:has(Identifier[name=createReducer])  CallExpression:has(Identifier[name=on]) > ArrowFunction:not(:has(TypeReference),:has(CallExpression))',
     ) as ts.CallExpression[]
 
     const failures = creators.map(

--- a/test/rules/ngrx-on-reducer-explicit-return-type/fixture.ts.lint
+++ b/test/rules/ngrx-on-reducer-explicit-return-type/fixture.ts.lint
@@ -72,7 +72,15 @@ on(
   }),
 ),
 on(increase, (s, { value }) => increaseFunc(s, value)),
-on(increase, (s, { value }): State => increaseFunc(s, value))
+on(increase, (s, { value }): State => increaseFunc(s, value)),
+// Do not match nested arrow functions
+on(
+  increment,
+  (s): State => ({
+    ...s,
+    counter: (s => s.counter + 1)(s),
+  }),
+),
 
 )
 


### PR DESCRIPTION
Currently this inner function will error with the `ngrx-on-reducer-explicit-return-type` rule.  This should not be the case and rule should only match on reducer callback functions.

```
on(
  increment,
  (s): State => ({
    ...s,
    counter: (s => s.counter + 1)(s),
  }),
),
```